### PR TITLE
Add partial no-std support

### DIFF
--- a/rustemo/Cargo.toml
+++ b/rustemo/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 
 [dependencies]
 colored = "2"
+fnv = "1.0.7"
 petgraph = { version = "0.6", optional = true }
 
 

--- a/rustemo/src/context.rs
+++ b/rustemo/src/context.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::{input::Input, lexer::Token, location::Location, parser::State};
 

--- a/rustemo/src/error.rs
+++ b/rustemo/src/error.rs
@@ -1,7 +1,7 @@
 use crate::{location::Location, Context, Input, State};
-use std::fmt::{Debug, Display};
+use core::fmt::{Debug, Display};
 
-pub type Result<R> = std::result::Result<R, Error>;
+pub type Result<R> = core::result::Result<R, Error>;
 
 /// Error type returned in `Err` variant of `Result` type from the parser.
 // ANCHOR: parser-error
@@ -51,7 +51,7 @@ impl Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Error {
                 message,

--- a/rustemo/src/glr/gss.rs
+++ b/rustemo/src/glr/gss.rs
@@ -1,10 +1,9 @@
-use std::{
-    cell::RefCell,
-    collections::{HashSet, VecDeque},
-    fmt::Debug,
-    ops::Range,
-    rc::Rc,
-};
+use alloc::collections::VecDeque;
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use core::fmt::Debug;
+use core::ops::Range;
+use fnv::FnvHashSet as HashSet;
 
 use petgraph::{graph::Edges, prelude::*};
 
@@ -486,12 +485,12 @@ where
 {
 }
 
-impl<'i, I, P, TK> std::hash::Hash for Parent<'i, I, P, TK>
+impl<'i, I, P, TK> core::hash::Hash for Parent<'i, I, P, TK>
 where
     I: Input + ?Sized,
     TK: Copy,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.root_node.hash(state);
         self.head_node.hash(state);
     }
@@ -565,7 +564,7 @@ where
     I: Input + ?Sized + Debug,
     TK: Copy,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match &*self.root {
             SPPFTree::Term { token, .. } => write!(f, "{:#?}", token.value),
             SPPFTree::NonTerm { .. } => write!(f, "{:#?}", self.children()),
@@ -743,7 +742,7 @@ where
     #[inline]
     pub fn ambiguities(&self) -> usize {
         #[allow(clippy::mutable_key_type)]
-        let mut visited: HashSet<Rc<Parent<'i, I, P, TK>>> = HashSet::new();
+        let mut visited: HashSet<Rc<Parent<'i, I, P, TK>>> = HashSet::default();
         self.results
             .iter()
             .map(|n| n.ambiguities(&mut visited))

--- a/rustemo/src/glr/parser.rs
+++ b/rustemo/src/glr/parser.rs
@@ -24,16 +24,13 @@ use crate::{
 #[cfg(debug_assertions)]
 use colored::*;
 use petgraph::prelude::*;
-use std::{
-    borrow::Borrow,
-    cell::RefCell,
-    collections::{BTreeMap, VecDeque},
-    fmt::{Debug, Display},
-    marker::PhantomData,
-    ops::Range,
-    rc::Rc,
-};
-
+use core::borrow::Borrow;
+use core::cell::RefCell;
+use core::fmt::{Debug, Display};
+use core::marker::PhantomData;
+use core::ops::Range;
+use alloc::collections::{BTreeMap, VecDeque};
+use alloc::rc::Rc;
 use super::gss::{Forest, GssGraph, GssHead, SPPFTree, TreeData};
 
 /// The start of the reduction. For length 0 it will carry the node of the
@@ -80,7 +77,7 @@ where
     I: Input + ?Sized,
     TK: Copy,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut pariter = self.parents.iter().rev();
         if let Some(parent) = pariter.next() {
             write!(f, "{}", parent.head_node.index())?;

--- a/rustemo/src/input.rs
+++ b/rustemo/src/input.rs
@@ -2,13 +2,11 @@ use crate::{
     error::Result,
     location::{LineColumn, Location, Position},
 };
-use std::{
-    borrow::ToOwned,
-    cmp::min,
-    iter::once,
-    ops::{Deref, Index, Range},
-    path::Path,
-};
+use alloc::borrow::ToOwned;
+use core::cmp::min;
+use core::iter::once;
+use core::ops::{Deref, Index, Range};
+use std::path::Path;
 /// Input is a sliceable sequence-like type with a concept of length.
 ///
 /// This trait must be implemented by all types that should be parsed by

--- a/rustemo/src/lexer.rs
+++ b/rustemo/src/lexer.rs
@@ -4,7 +4,7 @@ use crate::{
 #[cfg(debug_assertions)]
 use colored::*;
 use core::fmt::Debug;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// The trait implemented by all Rustemo lexers
 ///
@@ -219,7 +219,7 @@ where
     I::Output: Debug,
     TK: Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{:?}({:?} {:?})",

--- a/rustemo/src/lib.rs
+++ b/rustemo/src/lib.rs
@@ -4,6 +4,14 @@
 // #[doc(inline)]
 // pub use std;
 
+#![warn(
+    clippy::std_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::alloc_instead_of_core
+)]
+
+extern crate alloc;
+
 #[macro_use]
 mod common;
 #[macro_use]

--- a/rustemo/src/location.rs
+++ b/rustemo/src/location.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use core::fmt::{Debug, Display};
 
 /// A line-column based location for use where applicable (e.g. plain text).
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
@@ -55,7 +55,7 @@ impl Default for Position {
 }
 
 impl Display for Position {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Position::Position(pos) => write!(f, "{pos}"),
             Position::LineBased(lb) => write!(f, "{},{}", lb.line, lb.column),
@@ -95,7 +95,7 @@ impl Location {
 }
 
 impl Debug for Location {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.end {
             Some(ref end) => write!(f, "[{}-{}]", self.start, end),
             None => write!(f, "[{}]", self.start),
@@ -122,7 +122,7 @@ pub struct ValLoc<T> {
 }
 
 impl<T: Display> Display for ValLoc<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.value)
     }
 }

--- a/rustemo/src/lr/context.rs
+++ b/rustemo/src/lr/context.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::{
     context::Context, input::Input, lexer::Token, location::Location,

--- a/rustemo/src/lr/parser.rs
+++ b/rustemo/src/lr/parser.rs
@@ -9,14 +9,13 @@ use crate::parser::{Parser, State};
 use crate::{err, Error};
 #[cfg(debug_assertions)]
 use colored::*;
-use std::borrow::Borrow;
-use std::cell::RefCell;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::ops::Range;
+use core::borrow::Borrow;
+use core::cell::RefCell;
+use core::fmt::Debug;
+use core::marker::PhantomData;
+use core::ops::Range;
 use std::path::Path;
-use std::rc::Rc;
-
+use alloc::rc::Rc;
 use super::builder::LRBuilder;
 
 /// Provides LR actions and GOTOs given the state and term/nonterm.
@@ -44,7 +43,7 @@ struct StackItem<S> {
 }
 
 impl<S: Debug> Debug for StackItem<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "State({:?}, {:?} {:?})",
@@ -59,7 +58,7 @@ struct ParseStack<S, I: ?Sized, C, TK> {
 }
 
 impl<S: Debug, I: ?Sized, C, TK> Debug for ParseStack<S, I, C, TK> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ParseStack")
             .field("stack", &self.stack)
             .finish()


### PR DESCRIPTION
This PR just introduced Clippy rules that translate some std use to core/alloc as much as possible, despite there are some features required manual std feature marking. However, the biggest obstacle would still be `petgraph` since it is not yet no-std ready. So I keep this as more of a preparation. Once petgraph is going for 0.7.0 we can immediately change to no_std.