### PR TITLE
Fix #20, Make trace logs off by default, opt in

### DIFF
--- a/rustemo-compiler/src/main.rs
+++ b/rustemo-compiler/src/main.rs
@@ -28,9 +28,9 @@ struct Cli {
     #[clap(short, long, action)]
     noactions: bool,
 
-    /// Do not print trace logs
+    /// Print trace logs
     #[clap(long, action)]
-    notrace: bool,
+    trace: bool,
 
     /// Grammar file or directory to process
     #[clap(value_parser, value_name="GRAMMAR FILE/DIR", value_hint = clap::ValueHint::AnyPath)]
@@ -125,7 +125,7 @@ fn main() {
         .force(cli.force)
         .dot(cli.dot)
         .actions(!cli.noactions)
-        .notrace(cli.notrace)
+        .trace(cli.trace)
         .exclude(cli.exclude)
         .prefer_shifts(cli.prefer_shifts)
         .prefer_shifts_over_empty(!cli.no_shifts_over_empty)

--- a/rustemo-compiler/src/settings.rs
+++ b/rustemo-compiler/src/settings.rs
@@ -88,7 +88,7 @@ pub struct Settings {
     pub(crate) print_table: bool,
     pub(crate) exclude: Vec<String>,
     pub(crate) actions: bool,
-    pub(crate) notrace: bool,
+    pub(crate) trace: bool,
 
     pub(crate) lexer_type: LexerType,
     pub(crate) builder_type: BuilderType,
@@ -130,7 +130,7 @@ impl Default for Settings {
             parser_algo: Default::default(),
             print_table: false,
             actions: true,
-            notrace: false,
+            trace: false,
             lexer_type: Default::default(),
             builder_type: Default::default(),
             builder_loc_info: false,
@@ -341,16 +341,16 @@ impl Settings {
 
     /// Should trace log be printed. `false` by default. Does nothing for
     /// release builds as trace is only available in debug build. Can also be
-    /// set by `RUSTEMO_NOTRACE=1` env variable.
-    pub fn notrace(mut self, notrace: bool) -> Self {
-        let notrace = if !notrace {
-            std::env::var("RUSTEMO_NOTRACE").is_ok()
+    /// set by `RUSTEMO_TRACE=1` env variable.
+    pub fn trace(mut self, trace: bool) -> Self {
+        let trace = if !trace {
+            std::env::var("RUSTEMO_TRACE").is_ok()
         } else {
-            std::env::set_var("RUSTEMO_NOTRACE", "1");
+            std::env::set_var("RUSTEMO_TRACE", "1");
             true
         };
 
-        self.notrace = notrace;
+        self.trace = trace;
         self
     }
 

--- a/rustemo/src/debug.rs
+++ b/rustemo/src/debug.rs
@@ -5,14 +5,14 @@
 #[macro_export]
 #[cfg(debug_assertions)]
 macro_rules! logn {
-    ($( $args:expr ),*) => { if std::env::var("RUSTEMO_NOTRACE").is_err() { eprint!( $( $args ),* )}; }
+    ($( $args:expr ),*) => { if std::env::var_os("RUSTEMO_TRACE").is_some() { eprint!( $( $args ),* )}; }
 }
 
 /// Prints with newline to stdout in debug profile
 #[macro_export]
 #[cfg(debug_assertions)]
 macro_rules! log {
-    ($( $args:expr ),*) => { if std::env::var("RUSTEMO_NOTRACE").is_err() { eprintln!( $( $args ),* )}; }
+    ($( $args:expr ),*) => { if std::env::var_os("RUSTEMO_TRACE").is_some() { eprintln!( $( $args ),* )}; }
 }
 
 #[macro_export]


### PR DESCRIPTION
## Motivation
This fixes #20 .

I couldn't find
```
context.position() = 34
context.location() = [1,34]
```
anywhere in the code... was that possibly removed in a recent commit?

## Checklist
<!--
Note: this list does not have to be complete to submit a contribution!
Fill out what you can and feel free to ask for help with anything
-->
- [ ] added tests to verify new behavior
- [x] updated documentation if applicable.
- [ ] updated `CHANGELOG.md`
